### PR TITLE
Removing outdated .rvmrc

### DIFF
--- a/.rvmrc
+++ b/.rvmrc
@@ -1,1 +1,0 @@
-rvm use ruby-1.9.3-p194@rubyonrio --create


### PR DESCRIPTION
The ruby version was bumped to 2.1.0 on 4db301c1f2503d19ac and there's no sense on maintain the rvm old style while there are already a rbenv style ruby versioning file
